### PR TITLE
Add change for File Identifier, macro for Oauth 2 fields.

### DIFF
--- a/docs/GoogleDrive-batchsink.md
+++ b/docs/GoogleDrive-batchsink.md
@@ -43,6 +43,11 @@ Make sure that:
 OAuth2 client credentials can be generated on Google Cloud
 [Credentials Page](https://console.cloud.google.com/apis/credentials)
 
+**OAuth Method:** The method used to get OAuth access tokens. The oauth access token can be directly provided,
+or a client id, client secret, and refresh token can be provided.
+
+**Access Token:** Short lived access token for connect.
+
 **Client ID:** OAuth2 client id used to identify the application.
 
 **Client Secret:** OAuth2 client secret used to access the authorization server.

--- a/docs/GoogleDrive-batchsource.md
+++ b/docs/GoogleDrive-batchsource.md
@@ -17,6 +17,16 @@ https://drive.google.com/drive/folders/1dyUEebJaFnWa3Z4n0BFMVAXQ7mfUH11g?resourc
 ```
 Then the Directory Identifier would be `1dyUEebJaFnWa3Z4n0BFMVAXQ7mfUH11g`.
 
+**File Identifier:** Identifier of the file.
+
+This comes after `file/d/ or document/d/ or spreadsheets/d/` in the URL. For example, if the URL is
+```
+https://docs.google.com/file/d/17W3vOhBwe0i24OdVNsbz8rAMClzUitKeAbumTqWFrkows
+```
+Then the File Identifier would be `17W3vOhBwe0i24OdVNsbz8rAMClzUitKeAbumTqWFrkows`.  
+Either Directory Identifier or File Identifier should have a value. Filters will not work 
+while providing File Identifier.
+
 **File Metadata Properties:** Properties that represent metadata of files. 
 They will be a part of output structured record. Descriptions for properties can be view at 
 [Drive API file reference](https://developers.google.com/drive/api/v3/reference/files).
@@ -57,6 +67,11 @@ Make sure that:
 
 OAuth2 client credentials can be generated on Google Cloud
 [Credentials Page](https://console.cloud.google.com/apis/credentials)
+
+**OAuth Method:** The method used to get OAuth access tokens. The oauth access token can be directly provided,
+or a client id, client secret, and refresh token can be provided.
+
+**Access Token:** Short lived access token for connect.
 
 **Client ID:** OAuth2 client id used to identify the application.
 

--- a/docs/GoogleSheets-batchsink.md
+++ b/docs/GoogleSheets-batchsink.md
@@ -46,6 +46,11 @@ Make sure that:
 OAuth2 client credentials can be generated on Google Cloud
 [Credentials Page](https://console.cloud.google.com/apis/credentials)
 
+**OAuth Method:** The method used to get OAuth access tokens. The oauth access token can be directly provided,
+or a client id, client secret, and refresh token can be provided.
+
+**Access Token:** Short lived access token for connect.
+
 **Client ID:** OAuth2 client id used to identify the application.
 
 **Client Secret:** OAuth2 client secret used to access the authorization server.

--- a/docs/GoogleSheets-batchsource.md
+++ b/docs/GoogleSheets-batchsource.md
@@ -17,6 +17,16 @@ https://drive.google.com/drive/folders/1dyUEebJaFnWa3Z4n0BFMVAXQ7mfUH11g?resourc
 ```
 Then the Directory Identifier would be `1dyUEebJaFnWa3Z4n0BFMVAXQ7mfUH11g`.
 
+**File Identifier:** Identifier of the spreadsheet file.
+
+This comes after `spreadsheets/d/` in the URL. For example, if the URL is
+```
+https://docs.google.com/spreadsheets/d/17W3vOhBwe0i24OdVNsbz8rAMClzUitKeAbumTqWFrkows
+```
+Then the File Identifier would be `17W3vOhBwe0i24OdVNsbz8rAMClzUitKeAbumTqWFrkows`.  
+Either Directory Identifier or File Identifier should have a value. Filters will not work
+while providing File Identifier.
+
 ### Filtering
 
 **Filter:** Filter that can be applied to the files in the selected directory. 
@@ -54,6 +64,11 @@ Make sure that:
 
 OAuth2 client credentials can be generated on Google Cloud 
 [Credentials Page](https://console.cloud.google.com/apis/credentials)
+
+**OAuth Method:** The method used to get OAuth access tokens. The oauth access token can be directly provided,
+or a client id, client secret, and refresh token can be provided.
+
+**Access Token:** Short lived access token for connect.
 
 **Client ID:** OAuth2 client id used to identify the application.
 
@@ -124,10 +139,10 @@ _Treat first row as column names_ - the plugin uses first row for schema definin
 **Column Names Row Number:** Number of the row to be treated as a header.
 Only shown when the 'Column Names Selection' field is set to 'Custom row as column names' header.
 
-**Number of Columns to Read:** Last column plugin will read as data. It will be ignored if the Column 
-Names Row contains less number of columns.
+**Number of Columns to Read:** Last column plugin will read as data. It will be ignored if the Column
+Names Row contains less number of columns. Set it to 0 to read all the columns in the sheet.
 
-**Number of Rows to Read:** Last row plugin will read as data.
+**Number of Rows to Read:** Last row plugin will read as data. Set it to 0 to read all the rows in the sheet.
 
 **Read Buffer Size:** Number of rows the source reads with a single API request. Default value is 100.
 

--- a/src/main/java/io/cdap/plugin/google/common/GoogleDriveFilteringClient.java
+++ b/src/main/java/io/cdap/plugin/google/common/GoogleDriveFilteringClient.java
@@ -71,6 +71,10 @@ public class GoogleDriveFilteringClient<C extends GoogleFilteringSourceConfig> e
       String nextToken = "";
       int retrievedFiles = 0;
       int actualFilesNumber = filesNumber;
+      if (config.getFileIdentifier() != null) {
+        files.add(service.files().get(config.getFileIdentifier()).setSupportsAllDrives(true).execute());
+        return files;
+      }
       Drive.Files.List request = service.files().list()
         .setSupportsAllDrives(true)
         .setIncludeItemsFromAllDrives(true)

--- a/src/main/java/io/cdap/plugin/google/common/OAuthMethod.java
+++ b/src/main/java/io/cdap/plugin/google/common/OAuthMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Cask Data, Inc.
+ * Copyright © 2024 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,20 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.cdap.plugin.google.common;
 
 /**
- * Wrapper to save validation results. Is used to transfer validation results.
+ * Methods of getting an OAuth access token.
  */
-public class ValidationResult {
-  private boolean directoryOrFileAccessible = false;
-
-  public boolean isDirectoryOrFileAccessible() {
-    return directoryOrFileAccessible;
-  }
-
-  public void setDirectoryOrFileAccessible(boolean directoryOrFileAccessible) {
-    this.directoryOrFileAccessible = directoryOrFileAccessible;
-  }
+public enum OAuthMethod {
+  ACCESS_TOKEN,
+  REFRESH_TOKEN;
 }

--- a/src/main/java/io/cdap/plugin/google/drive/source/GoogleDriveSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/google/drive/source/GoogleDriveSourceConfig.java
@@ -324,6 +324,10 @@ public class GoogleDriveSourceConfig extends GoogleFilteringSourceConfig {
       googleDriveSourceConfig.setDirectoryIdentifier(
         properties.get(GoogleDriveSourceConfig.DIRECTORY_IDENTIFIER).getAsString());
     }
+    if (properties.has(GoogleDriveSourceConfig.FILE_IDENTIFIER)) {
+      googleDriveSourceConfig.setFileIdentifier(
+        properties.get(GoogleDriveSourceConfig.FILE_IDENTIFIER).getAsString());
+    }
     if (properties.has(GoogleDriveSourceConfig.FILTER)) {
       googleDriveSourceConfig.setFilter(properties.get(GoogleDriveSourceConfig.FILTER).getAsString());
     }
@@ -363,6 +367,12 @@ public class GoogleDriveSourceConfig extends GoogleFilteringSourceConfig {
     }
     if (properties.has(GoogleDriveSourceConfig.REFRESH_TOKEN)) {
       googleDriveSourceConfig.setRefreshToken(properties.get(GoogleDriveSourceConfig.REFRESH_TOKEN).getAsString());
+    }
+    if (properties.has(GoogleDriveSourceConfig.ACCESS_TOKEN)) {
+      googleDriveSourceConfig.setAccessToken(properties.get(GoogleDriveSourceConfig.ACCESS_TOKEN).getAsString());
+    }
+    if (properties.has(GoogleDriveSourceConfig.OAUTH_METHOD)) {
+      googleDriveSourceConfig.setOauthMethod(properties.get(GoogleDriveSourceConfig.OAUTH_METHOD).getAsString());
     }
     return googleDriveSourceConfig;
   }

--- a/src/test/java/io/cdap/plugin/google/common/GoogleAuthBaseConfigTest.java
+++ b/src/test/java/io/cdap/plugin/google/common/GoogleAuthBaseConfigTest.java
@@ -57,6 +57,7 @@ public class GoogleAuthBaseConfigTest {
     config.setModificationDateRange("today");
     config.getBodyFormat("string");
     config.setStartDate("today");
+    config.setFileIdentifier("fileId");
     FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
     config.validate(collector);
     Assert.assertEquals(1, collector.getValidationFailures().size());
@@ -76,6 +77,7 @@ public class GoogleAuthBaseConfigTest {
     config.setModificationDateRange("today");
     config.getBodyFormat("string");
     config.setStartDate("today");
+    config.setFileIdentifier("fileId");
     FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
     config.validate(collector);
     Assert.assertEquals(1, collector.getValidationFailures().size());
@@ -83,5 +85,72 @@ public class GoogleAuthBaseConfigTest {
                         collector.getValidationFailures().get(0).getMessage());
     Assert.assertEquals("serviceAccountJSON",
                         collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
+  }
+
+  @Test
+  public void testWithBothFileAndDirectoryAsNull() {
+    GoogleDriveSourceConfig config = new GoogleDriveSourceConfig("ref");
+    config.setReferenceName("validationErrorFilePath");
+    config.setAuthType("oAuth2");
+    config.setModificationDateRange("today");
+    config.getBodyFormat("string");
+    config.setStartDate("today");
+    config.setAccessToken("access");
+    config.setOauthMethod(OAuthMethod.ACCESS_TOKEN.name());
+    FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
+    config.validate(collector);
+    Assert.assertEquals(1, collector.getValidationFailures().size());
+    Assert.assertEquals("Both Directory Identifier and File Identifier can not be null.",
+                        collector.getValidationFailures().get(0).getMessage());
+    Assert.assertEquals("directoryIdentifier",
+                        collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
+    Assert.assertEquals("fileIdentifier",
+                        collector.getValidationFailures().get(0).getCauses().get(1).getAttribute("stageConfig"));
+  }
+
+  @Test
+  public void testValidationOauthWithoutAccessToken() {
+    GoogleDriveSourceConfig config = new GoogleDriveSourceConfig("ref");
+    config.setReferenceName("validationErrorFilePath");
+    config.setAuthType("oAuth2");
+    config.setOauthMethod(OAuthMethod.ACCESS_TOKEN.name());
+    config.setModificationDateRange("today");
+    config.getBodyFormat("string");
+    config.setStartDate("today");
+    config.setFileIdentifier("file");
+    FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
+    config.validate(collector);
+    Assert.assertEquals(1, collector.getValidationFailures().size());
+    Assert.assertEquals("'Access token' property is empty or macro is not available.",
+                        collector.getValidationFailures().get(0).getMessage());
+    Assert.assertEquals("accessToken",
+                        collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
+  }
+
+  @Test
+  public void testValidationOauthWithoutRefreshToken() {
+    GoogleDriveSourceConfig config = new GoogleDriveSourceConfig(null);
+    config.setReferenceName("validationErrorFilePath");
+    config.setAuthType("oAuth2");
+    config.setOauthMethod(OAuthMethod.REFRESH_TOKEN.name());
+    config.setModificationDateRange("today");
+    config.getBodyFormat("string");
+    config.setStartDate("today");
+    config.setFileIdentifier("file");
+    FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
+    config.validate(collector);
+    Assert.assertEquals(3, collector.getValidationFailures().size());
+    Assert.assertEquals("'Client ID' property is empty or macro is not available.",
+                        collector.getValidationFailures().get(0).getMessage());
+    Assert.assertEquals("'Client secret' property is empty or macro is not available.",
+                        collector.getValidationFailures().get(1).getMessage());
+    Assert.assertEquals("'Refresh token' property is empty or macro is not available.",
+                        collector.getValidationFailures().get(2).getMessage());
+    Assert.assertEquals("clientId",
+                        collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
+    Assert.assertEquals("clientSecret",
+                        collector.getValidationFailures().get(1).getCauses().get(0).getAttribute("stageConfig"));
+    Assert.assertEquals("refreshToken",
+                        collector.getValidationFailures().get(2).getCauses().get(0).getAttribute("stageConfig"));
   }
 }

--- a/src/test/java/io/cdap/plugin/google/sheets/sink/GoogleSheetsSinkClientTest.java
+++ b/src/test/java/io/cdap/plugin/google/sheets/sink/GoogleSheetsSinkClientTest.java
@@ -21,6 +21,7 @@ import com.google.api.services.sheets.v4.model.GridRange;
 import com.google.api.services.sheets.v4.model.MergeCellsRequest;
 import com.google.api.services.sheets.v4.model.RowData;
 import io.cdap.plugin.google.common.AuthType;
+import io.cdap.plugin.google.common.OAuthMethod;
 import io.cdap.plugin.google.sheets.sink.utils.ComplexHeader;
 import io.cdap.plugin.google.sheets.sink.utils.FlatteredRowsRecord;
 import io.cdap.plugin.google.sheets.sink.utils.FlatteredRowsRequest;
@@ -46,6 +47,7 @@ public class GoogleSheetsSinkClientTest {
   public static void setupClient() throws IOException {
     sinkConfig = EasyMock.createMock(GoogleSheetsSinkConfig.class);
     EasyMock.expect(sinkConfig.getAuthType()).andReturn(AuthType.OAUTH2).anyTimes();
+    EasyMock.expect(sinkConfig.getOAuthMethod()).andReturn(OAuthMethod.REFRESH_TOKEN).anyTimes();
     EasyMock.expect(sinkConfig.getRefreshToken()).andReturn("dsfdsfdsfdsf").anyTimes();
     EasyMock.expect(sinkConfig.getClientSecret()).andReturn("dsfdsfdsfdsf").anyTimes();
     EasyMock.expect(sinkConfig.getClientId()).andReturn("dsdsrfegvrb").anyTimes();

--- a/widgets/GoogleDrive-batchsink.json
+++ b/widgets/GoogleDrive-batchsink.json
@@ -31,6 +31,11 @@
           "widget-type": "textbox",
           "label": "Directory Identifier",
           "name": "directoryIdentifier"
+        },
+        {
+          "widget-type": "hidden",
+          "label": "File Identifier",
+          "name": "fileIdentifier"
         }
       ]
     },
@@ -54,6 +59,33 @@
                 "label": "Service account"
               }
             ]
+          }
+        },
+        {
+          "name": "oauthMethod",
+          "label": "OAuth Method",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "REFRESH_TOKEN",
+            "options": [
+              {
+                "id": "REFRESH_TOKEN",
+                "label": "Refresh Token"
+              },
+              {
+                "id": "ACCESS_TOKEN",
+                "label": "Access Token"
+              }
+            ]
+          }
+        },
+        {
+          "name": "accessToken",
+          "label": "Access Token",
+          "widget-type": "textbox",
+          "widget-attributes": {
+            "placeholder": "${oauthAccessToken(provider,credential)}"
           }
         },
         {
@@ -114,6 +146,30 @@
         "property": "authType",
         "operator": "equal to",
         "value": "oAuth2"
+      },
+      "show": [
+        {
+          "name": "oauthMethod",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Access Token",
+      "condition": {
+        "expression": "oauthMethod == 'ACCESS_TOKEN' && authType == 'oAuth2'"
+      },
+      "show": [
+        {
+          "name": "accessToken",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Refresh Token",
+      "condition": {
+        "expression": "oauthMethod == 'REFRESH_TOKEN' && authType == 'oAuth2'"
       },
       "show": [
         {

--- a/widgets/GoogleDrive-batchsource.json
+++ b/widgets/GoogleDrive-batchsource.json
@@ -18,6 +18,11 @@
           "name": "directoryIdentifier"
         },
         {
+          "widget-type": "textbox",
+          "label": "File Identifier",
+          "name": "fileIdentifier"
+        },
+        {
           "name": "fileMetadataProperties",
           "widget-type": "multi-select",
           "label": "File Metadata Properties",
@@ -312,6 +317,33 @@
           }
         },
         {
+          "name": "oauthMethod",
+          "label": "OAuth Method",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "REFRESH_TOKEN",
+            "options": [
+              {
+                "id": "REFRESH_TOKEN",
+                "label": "Refresh Token"
+              },
+              {
+                "id": "ACCESS_TOKEN",
+                "label": "Access Token"
+              }
+            ]
+          }
+        },
+        {
+          "name": "accessToken",
+          "label": "Access Token",
+          "widget-type": "textbox",
+          "widget-attributes": {
+            "placeholder": "${oauthAccessToken(provider,credential)}"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Client ID",
           "name": "clientId"
@@ -487,6 +519,30 @@
         "property": "authType",
         "operator": "equal to",
         "value": "oAuth2"
+      },
+      "show": [
+        {
+          "name": "oauthMethod",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Access Token",
+      "condition": {
+        "expression": "oauthMethod == 'ACCESS_TOKEN' && authType == 'oAuth2'"
+      },
+      "show": [
+        {
+          "name": "accessToken",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Refresh Token",
+      "condition": {
+        "expression": "oauthMethod == 'REFRESH_TOKEN' && authType == 'oAuth2'"
       },
       "show": [
         {

--- a/widgets/GoogleSheets-batchsink.json
+++ b/widgets/GoogleSheets-batchsink.json
@@ -18,6 +18,11 @@
           "name": "directoryIdentifier"
         },
         {
+          "widget-type": "hidden",
+          "label": "File Identifier",
+          "name": "fileIdentifier"
+        },
+        {
           "widget-type": "textbox",
           "label": "Spreadsheet Name Field",
           "name": "schemaSpreadsheetNameFieldName"
@@ -114,6 +119,33 @@
           "widget-type": "textbox",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
+        },
+        {
+          "name": "oauthMethod",
+          "label": "OAuth Method",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "REFRESH_TOKEN",
+            "options": [
+              {
+                "id": "REFRESH_TOKEN",
+                "label": "Refresh Token"
+              },
+              {
+                "id": "ACCESS_TOKEN",
+                "label": "Access Token"
+              }
+            ]
+          }
+        },
+        {
+          "name": "accessToken",
+          "label": "Access Token",
+          "widget-type": "textbox",
+          "widget-attributes": {
+            "placeholder": "${oauthAccessToken(provider,credential)}"
+          }
         },
         {
           "widget-type": "textbox",
@@ -234,7 +266,33 @@
     {
       "name": "Authenticate with OAuth2",
       "condition": {
-        "expression": "authType == 'oAuth2'"
+        "property": "authType",
+        "operator": "equal to",
+        "value": "oAuth2"
+      },
+      "show": [
+        {
+          "name": "oauthMethod",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Access Token",
+      "condition": {
+        "expression": "oauthMethod == 'ACCESS_TOKEN' && authType == 'oAuth2'"
+      },
+      "show": [
+        {
+          "name": "accessToken",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Refresh Token",
+      "condition": {
+        "expression": "oauthMethod == 'REFRESH_TOKEN' && authType == 'oAuth2'"
       },
       "show": [
         {

--- a/widgets/GoogleSheets-batchsource.json
+++ b/widgets/GoogleSheets-batchsource.json
@@ -16,6 +16,11 @@
           "widget-type": "textbox",
           "label": "Directory Identifier",
           "name": "directoryIdentifier"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "File Identifier",
+          "name": "fileIdentifier"
         }
       ]
     },
@@ -142,6 +147,33 @@
           "widget-type": "textbox",
           "label": "Service Account JSON",
           "name": "serviceAccountJSON"
+        },
+        {
+          "name": "oauthMethod",
+          "label": "OAuth Method",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "REFRESH_TOKEN",
+            "options": [
+              {
+                "id": "REFRESH_TOKEN",
+                "label": "Refresh Token"
+              },
+              {
+                "id": "ACCESS_TOKEN",
+                "label": "Access Token"
+              }
+            ]
+          }
+        },
+        {
+          "name": "accessToken",
+          "label": "Access Token",
+          "widget-type": "textbox",
+          "widget-attributes": {
+            "placeholder": "${oauthAccessToken(provider,credential)}"
+          }
         },
         {
           "widget-type": "textbox",
@@ -341,7 +373,7 @@
           "label": "Number of Columns to Read",
           "name": "lastDataColumn",
           "widget-attributes": {
-            "default": "26",
+            "default": "0",
             "min": "0"
           }
         },
@@ -350,7 +382,7 @@
           "label": "Number of Rows to Read",
           "name": "lastDataRow",
           "widget-attributes": {
-            "default": "1000",
+            "default": "0",
             "min": "0"
           }
         },
@@ -366,7 +398,12 @@
       ]
     }
   ],
-  "outputs": [],
+  "outputs": [
+    {
+      "name": "schema",
+      "widget-type": "schema"
+    }
+  ],
   "filters": [
     {
       "name": "Select modification date range",
@@ -404,6 +441,30 @@
         "property": "authType",
         "operator": "equal to",
         "value": "oAuth2"
+      },
+      "show": [
+        {
+          "name": "oauthMethod",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Access Token",
+      "condition": {
+        "expression": "oauthMethod == 'ACCESS_TOKEN' && authType == 'oAuth2'"
+      },
+      "show": [
+        {
+          "name": "accessToken",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Refresh Token",
+      "condition": {
+        "expression": "oauthMethod == 'REFRESH_TOKEN' && authType == 'oAuth2'"
       },
       "show": [
         {


### PR DESCRIPTION
Add changes for File Identifier, macro for Oauth 2 fields.
User can specify the file id instead of directory identifier and providing filters.
Macros added for oauth fields- clientId, clientSecret and refresh token.
Access token field added that can be used with oauthAccessToken macro.
Support for drive.file scope added by removing unnecessary checks for parent directory.
Added support to get all the rows and columns of google sheets instead of specifying the number each time.
